### PR TITLE
Add handling of NT_STATUS_INVALID_PARAMETER when finding users

### DIFF
--- a/enum4linux.pl
+++ b/enum4linux.pl
@@ -869,6 +869,8 @@ sub enum_users {
 	my $continue = 1;
 	if ($users =~ /NT_STATUS_ACCESS_DENIED/) {
 		print "[E] Couldn't find users using querydispinfo: NT_STATUS_ACCESS_DENIED\n";
+  } elsif ($users =~ /NT_STATUS_INVALID_PARAMETER/) {
+    print "[E] Couldn't find users using querydispinfo: NT_STATUS_INVALID_PARAMETER\n";
 	} else {
 		($users) = $users =~ /(index:.*)/s;
 		print $users;
@@ -883,6 +885,8 @@ sub enum_users {
 	$users = `$command`;
 	if ($users =~ /NT_STATUS_ACCESS_DENIED/) {
 		print "[E] Couldn't find users using enumdomusers: NT_STATUS_ACCESS_DENIED\n";
+  } elsif ($users =~ /NT_STATUS_INVALID_PARAMETER/) {
+    print "[E] Couldn't find users using enumdomusers: NT_STATUS_INVALID_PARAMETER\n";
 	} else {
 		($users) = $users =~ /(user:.*)/s;
 		print $users;


### PR DESCRIPTION
When enumerating older systems (i.e. Windows 2000), the enumeration of the users will frequently return a status of `NT_STATUS_INVALID_PARAMETER`. When this happens, enum4linux assumes it was successful, as it only checks against `NT_STATUS_ACCESS_DENIED` to determine a failure; which results in an error as per below:

```
root@kali:~# enum4linux -U XXX.XXX.XXX.XXX
Starting enum4linux v0.8.9 ( http://labs.portcullis.co.uk/application/enum4linux/ ) on Sun Oct  1 07:50:31 2017
***
 ============================ 
|    Users on XXX.XXX.XXX.XXX    |
 ============================ 
Use of uninitialized value $users in print at ./enum4linux.pl line 875.
Use of uninitialized value $users in pattern match (m//) at ./enum4linux.pl line 878.

Use of uninitialized value $users in print at ./enum4linux.pl line 889.
Use of uninitialized value $users in pattern match (m//) at ./enum4linux.pl line 891.
enum4linux complete on Sun Oct  1 07:50:34 2017
```
This pull request adds in the validation for the invalid parameter status for older systems, and handles it properly. The same request from the above output, repeated with this patch, results in the below:

```
root@kali:~# enum4linux -U XXX.XXX.XXX.XXX
Starting enum4linux v0.8.9 ( http://labs.portcullis.co.uk/application/enum4linux/ ) on Sun Oct  1 07:56:08 2017

***
 ============================ 
|    Users on XXX.XXX.XXX.XXX   |
 ============================ 
[E] Couldn't find users using querydispinfo: NT_STATUS_INVALID_PARAMETER

[E] Couldn't find users using enumdomusers: NT_STATUS_INVALID_PARAMETER
enum4linux complete on Sun Oct  1 07:56:11 2017
```