### PR TITLE
Updated enum4linux.pl to better handle single quote character in username and password

### DIFF
--- a/enum4linux.pl
+++ b/enum4linux.pl
@@ -309,8 +309,8 @@ if (defined($global_workgroup)) {
 foreach my $known_username (@global_known_usernames) {
 	$known_username =~ s/'/'\''/g; ($known_username) = $known_username =~ /(.*)/;
 }
-$global_username =~ s/'/'\''/g;       ($global_username)       = $global_username       =~ /(.*)/;
-$global_password =~ s/'/'\''/g;       ($global_password)       = $global_password       =~ /(.*)/;
+$global_username =~ s/'/'\\''/g;       ($global_username)       = $global_username       =~ /(.*)/;
+$global_password =~ s/'/'\\''/g;       ($global_password)       = $global_password       =~ /(.*)/;
 
 # Output message about options used
 print "Starting enum4linux v$VERSION ( http://labs.portcullis.co.uk/application/enum4linux/ ) on " .  scalar(localtime) . "\n";


### PR DESCRIPTION
Fix single quote escaping of username and password.
Before the fix, when sending a single quote in the username or password, there was a "Syntax error: Unterminated quoted string" exception